### PR TITLE
Potential fix for code scanning alert no. 56: Uncontrolled data used in path expression

### DIFF
--- a/LLM/src/st_rag_chat.py
+++ b/LLM/src/st_rag_chat.py
@@ -87,8 +87,10 @@ def load_document(source_path, source_type="URL"):
         # Load from local file in data folder
         current_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # Go up to LLM folder
         data_dir = os.path.join(current_dir, "data")
-        full_path = os.path.join(data_dir, source_path)
-        
+        # Normalize and validate that full_path stays within data_dir
+        full_path = os.path.normpath(os.path.join(data_dir, source_path))
+        if not full_path.startswith(os.path.abspath(data_dir) + os.sep):
+            raise ValueError("Access to files outside the data directory is not allowed.")
         if not os.path.exists(full_path):
             raise FileNotFoundError(f"File not found: {full_path}")
         


### PR DESCRIPTION
Potential fix for [https://github.com/intel/AI-PC-Samples/security/code-scanning/56](https://github.com/intel/AI-PC-Samples/security/code-scanning/56)

To fix the issue, we need to ensure that any path constructed for accessing local files under the `data` directory is validated such that it remains within the `data` directory and cannot escape via `..`, absolute paths, or symlinks. The best approach is to join the base directory with the user-supplied path, normalize the result (with `os.path.normpath`), and then check that the resulting path starts with the intended base directory (`data_dir`). If the check fails, raise an error and do not proceed to read the file. 

Changes are needed only in the `load_document` function, specifically in the "else" block when loading from the local file system (lines 88-103). No other logic or functionality needs to change. No external packages are required for this mitigation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
